### PR TITLE
Fix initialPeriod incorrectly set

### DIFF
--- a/classes/class.pmprogateway_ccbill.php
+++ b/classes/class.pmprogateway_ccbill.php
@@ -593,9 +593,13 @@ class PMProGateway_CCBill extends PMProGateway {
 			$period = min( $period, 365 );
 			
 			// NOTE: We're not supporting custom trials right now. Probably can't.
+		} else if ( $order->getMembershipLevel()->enddate ) {
+			// Get the levels expiration and convert it to days.
+			$expiration_date = date( 'Y-m-d', $order->getMembershipLevel()->enddate );
+			$order_date = date( "Y-m-d", $order->timestamp );
+			$period = round( ( strtotime( $expiration_date ) - strtotime( $order_date ) ) / DAY_IN_SECONDS ); 
 		} else {
-			// Set period to 1 for one time payments.
-			$period = 1;
+			$period = 2; //CCBill doesn't allow period values of 1.
 		}
 
 		return $period;


### PR DESCRIPTION
* BUG FIX: Fixed an issue where the get_initialPeriod wasn't being set correctly for levels with expiration dates. This now calculates the required initialPeriod (in days) 

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-ccbill/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-ccbill/pulls) for the same update/change?