### PR TITLE
Add support for renewal failures

### DIFF
--- a/webhook.php
+++ b/webhook.php
@@ -72,6 +72,19 @@ switch( $event_type ) {
 		
 	break;
 
+	case 'RenewalFailure':
+		
+		$subscription_id = sanitize_text_field( $response['subscriptionId'] );
+		
+		$morder = new MemberOrder();
+		$morder->getLastMemberOrderBySubscriptionTransactionID( $subscription_id );
+		$morder->getMembershipLevel();
+		$morder->getUser();
+		
+		if(pmpro_ccbill_RecurringCancel($morder))
+			pmpro_ccbill_Exit();
+	break;
+
 	default:
 		do_action('pmpro_ccbill_other_webhook_events', $event_type);
 		pmpro_ccbill_Exit();


### PR DESCRIPTION
* ENHANCEMENT: Added support for renewal failure events. This will trigger when a subscription charge fails to process and will remove the members level for this event type.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-ccbill/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-ccbill/pulls) for the same update/change?
