### PR TITLE
46 Bugfix: Change `PMPRO_CCBILL_DEBUG` to `true`

### DIFF
--- a/webhook.php
+++ b/webhook.php
@@ -1,7 +1,7 @@
 <?php
 
 //set this in your wp-config.php for debugging
-//define('PMPRO_CCBILL_DEBUG', true);
+//define( 'PMPRO_CCBILL_DEBUG', true );
 
 global $wpdb, $gateway_environment, $logstr;
 
@@ -254,7 +254,7 @@ function pmpro_ccbill_Exit( $redirect = false ) {
 	//echo $logstr;
 	$logstr = var_export( $_REQUEST, true ) . sprintf( __( 'Logged On: %s', 'pmpro-ccbill' ), date_i18n("m/d/Y H:i:s") ) . "\n" . $logstr . "\n-------------\n";
 	//log in file or email?
-	if ( defined( 'PMPRO_CCBILL_DEBUG' ) && PMPRO_CCBILL_DEBUG === "log" ) {
+	if ( defined( 'PMPRO_CCBILL_DEBUG' ) && PMPRO_CCBILL_DEBUG === true ) {
 		//file
 		$loghandle = fopen(PMPRO_CCBILL_DIR. "/logs/ccbill_webhook.txt", "a+");
 		fwrite($loghandle, $logstr);


### PR DESCRIPTION
https://github.com/strangerstudios/pmpro-ccbill/issues/46 Debug flag isn't working.

As instructed on line 4, use `true` instead of `'log'` to indicate events should be logged.

Instructions state:

```
//set this in your wp-config.php for debugging
//define( 'PMPRO_CCBILL_DEBUG', true );
```

Code was looking for:
`PMPRO_CCBILL_DEBUG === "log"`


### All Submissions:

* [ ] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-ccbill/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-ccbill/pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

> Change debug flag to look for `true` instead of `log`.
