### PR TITLE
[enhancement] * Change `pmpro_checkout_before_change_membership_level()` to run duriing `process()`

### DIFF
--- a/classes/class.pmprogateway_ccbill.php
+++ b/classes/class.pmprogateway_ccbill.php
@@ -34,7 +34,6 @@ class PMProGateway_CCBill extends PMProGateway {
 			add_filter( 'pmpro_include_payment_information_fields', '__return_false');
 			add_filter( 'pmpro_required_billing_fields', array( 'PMProGateway_CCBill', 'pmpro_required_billing_fields' ) );
 			add_filter( 'pmpro_checkout_default_submit_button', array( 'PMProGateway_CCBill', 'pmpro_checkout_default_submit_button' ) );
-			add_filter( 'pmpro_checkout_before_change_membership_level', array( 'PMProGateway_CCBill', 'pmpro_checkout_before_change_membership_level' ), 10, 2);
 		}
 	}
 
@@ -329,15 +328,14 @@ class PMProGateway_CCBill extends PMProGateway {
 		if ( empty( $order->code ) ) {
 			$order->code = $order->getRandomCode();
 		}
-
 		//clean up a couple values
 		$order->payment_type = "CCBill";
 		$order->CardType = "";
 		$order->cardtype = "";
-
-		//just save, the user will go to CCBill to pay
 		$order->status = "pending";
-		$order->saveOrder();
+		//do we still need to assign these above to the order ?
+
+		self::pmpro_checkout_before_change_membership_level( $order->user_id, $order );
 		return true;
 	}
 


### PR DESCRIPTION

  * Removed add_filter at the top of the class.
  * Removed unneeded save order within process () function ( will be called later within pmpro_checkout_before_change_membership_level) 
  * Call pmpro_checkout_before_change_membership_level at the end of process () function 

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-ccbill/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-ccbill/pulls) for the same update/change?


### Changes proposed in this Pull Request:

  * Removed add_filter at the top of the class.
  * Removed unneeded save order within process () function ( will be called later within pmpro_checkout_before_change_membership_level) 
  * Call pmpro_checkout_before_change_membership_level at the end of process () function 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
