### PR TITLE
[ENHANCEMENT] NewSaleSuccess webhook Use the `pmpro_complete_checkout…

### DIFF
--- a/webhook.php
+++ b/webhook.php
@@ -33,14 +33,13 @@ switch ( $event_type ) {
 
 		$order_id = sanitize_text_field( $response['X-pmpro_orderid'] );
 		$morder = new MemberOrder( $order_id );
-		$morder->getMembershipLevel();
-		$morder->getUser();
-		
-		if ( pmpro_ccbill_ChangeMembershipLevel( $response, $morder ) ) {
+
+		//run the function to complete checkout
+		if ( pmpro_complete_checkout( $morder ) ) {
 			//Log the event
 			pmpro_ccbill_webhook_log( sprintf( __( "Checkout processed (%s) success!", 'pmpro_ccbill'), $morder->code ) );
 		}
-		
+
 		pmpro_ccbill_Exit();
 		
 	break;
@@ -80,7 +79,19 @@ switch ( $event_type ) {
 	break;	
 }
 
+
+/**
+ *  Change Membership Level for CCBill. Deprecated,use pmpro_complete_checkout instead.
+ *
+ * @param  array $response
+ * @param  MemberOrder $morder
+ * @return bool
+ * @since TBD
+ * @deprecated TBD
+ */
 function pmpro_ccbill_ChangeMembershipLevel( $response, $morder ) {
+	//show deprecated message
+	_deprecated_function( __FUNCTION__, 'TBD', 'pmpro_complete_checkout' );
 
 	//filter for level
 	$morder->membership_level = apply_filters( "pmpro_ccbill_handler_level", $morder->membership_level, $morder->user_id );


### PR DESCRIPTION
…()` function

 * deprecate pmpro_ccbill_ChangeMembershipLevel
 * call pmpro_complete_checkout instead of pmpro_ccbill_ChangeMembershipLevel.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-ccbill/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-ccbill/pulls) for the same update/change?



### Changes proposed in this Pull Request:

 * deprecate pmpro_ccbill_ChangeMembershipLevel
 * call pmpro_complete_checkout instead of pmpro_ccbill_ChangeMembershipLevel.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
