### PR TITLE
[ENHANCEMENT] Add `cancel_subscription()` method

### DIFF
--- a/classes/class.pmprogateway_ccbill.php
+++ b/classes/class.pmprogateway_ccbill.php
@@ -491,6 +491,13 @@ class PMProGateway_CCBill extends PMProGateway {
 		exit;
 	}
 
+	/**
+	 * Process a cancellation in CCBill.
+	 *
+	 * @param object $order
+	 * @return boolean
+	 * @since TBD
+	 */
 	function cancel( &$order ) {
 
 		//no matter what happens below, we're going to cancel the order in our system
@@ -547,11 +554,11 @@ class PMProGateway_CCBill extends PMProGateway {
 				$email = get_option("admin_email");
 				wp_mail($email, get_option("blogname") . __( ' CCBill Subscription Cancel Error', 'pmpro-ccbill' ), $cancel_error);
 			} else {
-				// Success
+				//success, let's return true
+				return true;
 			}
 		}
-    
-		return $order;
+		return false;
 	}
 
 	function pmprocb_return_api_response( $code ) {
@@ -624,5 +631,25 @@ class PMProGateway_CCBill extends PMProGateway {
 		//Convert $level->expiration_period + $level->expiration_number to a date.
 		$expiration_date = date( "Y-m-d", strtotime( "+ " . $level->expiration_number . " " . $level->expiration_period, current_time( "timestamp" ) ) );
 		return $expiration_date;
+	}
+
+	/**
+	 * Cancels a subscription in CCBill.
+	 *
+	 * @param PMPro_Subscription $subscription to cancel.
+	 * @return bool True if successful, false otherwise.
+	 * @since TBD
+	 */
+	function cancel_subscription( $subscription ) {
+		//get subscription id
+		$subscription_id = $subscription->get_subscription_transaction_id();
+		$last_order = $subscription->get_orders( array( 'subscription_transaction_id' => $subscription_id, 'limit' => 1 ) );
+
+		//Bail if no order found.
+		if ( empty( $last_order ) ) {
+			return false;
+		}
+
+		return $this->cancel( $last_order[0] );
 	}
 }

--- a/classes/class.pmprogateway_ccbill.php
+++ b/classes/class.pmprogateway_ccbill.php
@@ -494,71 +494,20 @@ class PMProGateway_CCBill extends PMProGateway {
 	/**
 	 * Process a cancellation in CCBill.
 	 *
-	 * @param object $order
-	 * @return boolean
+	 * @param MemberOrder $order The order object.
+	 * @return boolean True if canceled successfuly, false otherwise.
 	 * @since TBD
 	 */
 	function cancel( &$order ) {
-
 		//no matter what happens below, we're going to cancel the order in our system
-
 		$order->updateStatus( "cancelled" );
 		//require a payment transaction id
 		if ( empty( $order->subscription_transaction_id ) ) {
 			return false;
 		}
 
-		//build the URL
-		$sms_link = "https://datalink.ccbill.com/utils/subscriptionManagement.cgi?";
-
-		$qargs = array();
-		$qargs["action"]		= "cancelSubscription";
-		$qargs["clientSubacc"]	= '';
-		$qargs["usingSubacc"]	= get_option('pmpro_ccbill_subaccount_number');
-		$qargs["subscriptionId"] = $order->subscription_transaction_id;
-		$qargs["clientAccnum"]	= get_option('pmpro_ccbill_account_number');
-		$qargs["username"]		= get_option('pmpro_ccbill_datalink_username'); //must be provided by CCBill
-		$qargs["password"]		= get_option('pmpro_ccbill_datalink_password'); //must be provided by CCBill
-
-		$cancel_link	= add_query_arg( $qargs, $sms_link );
-		$response		= wp_remote_get( $cancel_link );
-
-		$response_code		= wp_remote_retrieve_response_code( $response );
-		$response_message	= wp_remote_retrieve_response_message( $response );
-
-		if ( 200 != $response_code && !empty( $response_message ) ) {
-			//return new WP_Error( $response_code, $response_message );
-			$cancel_error = sprintf( __( 'Cancellation of subscription id: %s may have failed. Check CCBill Admin to confirm cancellation', 'pmpro-ccbill'), $order->subscription_transaction_id );
-
-			$email = get_option("admin_email");
-
-			wp_mail( $email, get_option("blogname") . __( ' CCBill Subscription Cancel Error', 'pmpro-ccbill' ), $cancel_error );
-
-		} else if ( 200 != $response_code ) {
-
-			//Unknown Error Occurred
-			$cancel_error = sprintf( __( 'Cancellation of subscription id: %s may have failed. Check CCBill Admin to confirm cancellation', 'pmpro-ccbill'), $order->subscription_transaction_id );
-
-			$email = get_option("admin_email");
-			wp_mail($email, get_option("blogname") . __( ' CCBill Subscription Cancel Error', 'pmpro-ccbill' ), $cancel_error);
-
-		} else {
-			$response_body = wp_remote_retrieve_body( $response );
-			$cancel_status = filter_var($response_body, FILTER_SANITIZE_NUMBER_INT);
-			if ( $cancel_status < 1 ) {
-				$error_code = $this->pmprocb_return_api_response( $cancel_status );
-
-				//A CCBill Error has occured. They need to contact CCBill
-				$cancel_error = sprintf( __( 'Cancellation of subscription id: %s may have failed. Check CCBill Admin to confirm cancellation. Error: %s', 'pmpro-ccbill'), $order->subscription_transaction_id, $error_code );
-
-				$email = get_option("admin_email");
-				wp_mail($email, get_option("blogname") . __( ' CCBill Subscription Cancel Error', 'pmpro-ccbill' ), $cancel_error);
-			} else {
-				//success, let's return true
-				return true;
-			}
-		}
-		return false;
+		//Call the cancel subscription at gateway function
+		return $this->cancel_subscription_at_gateway( $order->subscription_transaction_id );
 	}
 
 	function pmprocb_return_api_response( $code ) {
@@ -645,11 +594,77 @@ class PMProGateway_CCBill extends PMProGateway {
 		$subscription_id = $subscription->get_subscription_transaction_id();
 		$last_order = $subscription->get_orders( array( 'subscription_transaction_id' => $subscription_id, 'limit' => 1 ) );
 
-		//Bail if no order found.
+		//no order found, let's try to cancel the subscription at the gateway anyway
 		if ( empty( $last_order ) ) {
-			return false;
+			//try to cancel at the gateway
+			return $this->cancel_subscription_at_gateway( $subscription );
 		}
 
 		return $this->cancel( $last_order[0] );
+	}
+
+	/**
+	 * Cancels a subscription at the gateway.
+	 *
+	 * @param PMPro_Subscription $subscription The subscription object to cancel.
+	 * @return bool True if successful, false otherwise.
+	 * @since TBD
+	 */
+	function cancel_subscription_at_gateway( $subscription ) {
+		//bail if no subscription id
+		if ( empty( $subscription->id ) ) {
+			return false;
+		}
+		//build the URL
+		$sms_link = "https://datalink.ccbill.com/utils/subscriptionManagement.cgi?";
+
+		$qargs = array();
+		$qargs["action"]		= "cancelSubscription";
+		$qargs["clientSubacc"]	= '';
+		$qargs["usingSubacc"]	= get_option('pmpro_ccbill_subaccount_number');
+		$qargs["subscriptionId"] = $subscription->id;
+		$qargs["clientAccnum"]	= get_option('pmpro_ccbill_account_number');
+		$qargs["username"]		= get_option('pmpro_ccbill_datalink_username'); //must be provided by CCBill
+		$qargs["password"]		= get_option('pmpro_ccbill_datalink_password'); //must be provided by CCBill
+
+		$cancel_link	= add_query_arg( $qargs, $sms_link );
+		$response		= wp_remote_get( $cancel_link );
+
+		$response_code		= wp_remote_retrieve_response_code( $response );
+		$response_message	= wp_remote_retrieve_response_message( $response );
+
+		if ( 200 != $response_code && !empty( $response_message ) ) {
+			//return new WP_Error( $response_code, $response_message );
+			$cancel_error = sprintf( __( 'Cancellation of subscription id: %s may have failed. Check CCBill Admin to confirm cancellation', 'pmpro-ccbill'), $order->subscription_transaction_id );
+
+			$email = get_option("admin_email");
+
+			wp_mail( $email, get_option("blogname") . __( ' CCBill Subscription Cancel Error', 'pmpro-ccbill' ), $cancel_error );
+
+		} else if ( 200 != $response_code ) {
+
+			//Unknown Error Occurred
+			$cancel_error = sprintf( __( 'Cancellation of subscription id: %s may have failed. Check CCBill Admin to confirm cancellation', 'pmpro-ccbill'), $order->subscription_transaction_id );
+
+			$email = get_option("admin_email");
+			wp_mail($email, get_option("blogname") . __( ' CCBill Subscription Cancel Error', 'pmpro-ccbill' ), $cancel_error);
+
+		} else {
+			$response_body = wp_remote_retrieve_body( $response );
+			$cancel_status = filter_var($response_body, FILTER_SANITIZE_NUMBER_INT);
+			if ( $cancel_status < 1 ) {
+				$error_code = $this->pmprocb_return_api_response( $cancel_status );
+
+				//A CCBill Error has occured. They need to contact CCBill
+				$cancel_error = sprintf( __( 'Cancellation of subscription id: %s may have failed. Check CCBill Admin to confirm cancellation. Error: %s', 'pmpro-ccbill'), $order->subscription_transaction_id, $error_code );
+
+				$email = get_option("admin_email");
+				wp_mail($email, get_option("blogname") . __( ' CCBill Subscription Cancel Error', 'pmpro-ccbill' ), $cancel_error);
+			} else {
+				//success, let's return true
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/classes/class.pmprogateway_ccbill.php
+++ b/classes/class.pmprogateway_ccbill.php
@@ -602,7 +602,7 @@ class PMProGateway_CCBill extends PMProGateway {
 	 */
 	function cancel_subscription_at_gateway( $subscription_id ) {
 		//build the URL
-		$sms_link = "https://datalink.ccbill.com/utils/subscriptionManagement.cgi?";
+		$sms_link = "https://datalink.ccbill.com/utils/subscriptionManagement.cgi";
 
 		$qargs = array();
 		$qargs["action"]		= "cancelSubscription";


### PR DESCRIPTION
 * Add a cancel_subscription function that receives a subscription class instance

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-ccbill/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-ccbill/pulls) for the same update/change?


### Changes proposed in this Pull Request:

 * Add a cancel_subscription function that receives a subscription class instance and calls cancel function passing the last order from the subscription
 * Make Cancel function return boolean like it's done in Stripe and Payfast.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
