### PR TITLE
[ENHANCEMENT] Use the pmpro_handle_subscription_cancellation_at_gateway() function

### DIFF
--- a/webhook.php
+++ b/webhook.php
@@ -49,14 +49,9 @@ switch ( $event_type ) {
 	case 'Cancellation':
 		
 		$subscription_id = sanitize_text_field( $response['subscriptionId'] );
-		
-		$morder = new MemberOrder();
-		$morder->getLastMemberOrderBySubscriptionTransactionID( $subscription_id );
-		$morder->getMembershipLevel();
-		$morder->getUser();
-		
-		if(pmpro_ccbill_RecurringCancel($morder))
-			pmpro_ccbill_Exit();
+
+		pmpro_ccbill_webhook_log( pmpro_handle_subscription_cancellation_at_gateway( $subscription_id, 'ccbill', 'live' ) );
+		pmpro_ccbill_Exit();
 	break;
 
 	case 'RenewalSuccess':
@@ -341,7 +336,16 @@ function pmpro_ccbill_AddRenewal( array $response, $status = 'success' ) : void 
 
 }
 
+/**
+ * Cancel level for a subscription. Deprecated, call pmpro_handle_subscription_cancellation_at_gateway instead.
+ *
+ * @param MemberOrder $morder The order object.
+ * return bool True if the cancellation was successful, false otherwise.
+ * @since TBD
+ * @deprecated TBD
+ */
 function pmpro_ccbill_RecurringCancel( $morder ) {
+	_deprecated_function( __FUNCTION__, 'TBD', 'pmpro_handle_subscription_cancellation_at_gateway' );
 
 	global $pmpro_error;
 	$worked = pmpro_cancelMembershipLevel( $morder->membership_level->id, $morder->user_id, 'inactive' );


### PR DESCRIPTION


 * Remove order related code and call pmpro_handle_subscription_cancellation_at_gatway instead
 * Deprecate `pmpro_ccbill_RecurringCancel` function which isn't. called anymore

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-ccbill/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-ccbill/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

 * Remove order related code and call pmpro_handle_subscription_cancellation_at_gatway instead
 * Deprecate `pmpro_ccbill_RecurringCancel` function which isn't. called anymore



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
